### PR TITLE
fix(a2a): allowlist auth + actual redaction + denylist + Workers env

### DIFF
--- a/src/channels/a2a.ts
+++ b/src/channels/a2a.ts
@@ -25,9 +25,15 @@ export interface CreateA2aAppOpts {
   readonly maxBodySize?: number;
   // Test seam: override the runtime token validator. Production reads MOTE_A2A_TOKEN.
   readonly token?: string;
+  // Override model and agentCardUrl so callers (e.g. Workers) need not touch process.env.
+  readonly model?: string;
+  readonly agentCardUrl?: string;
 }
 
-const TOKEN_DENYLIST = new Set([
+// Substring denylist: any token whose lowercase representation contains one of
+// these strings is rejected. This catches padded variants like
+// "testtesttesttesttesttesttesttest" that exact-match sets would miss.
+const TOKEN_DENYLIST_SUBSTRINGS = [
   "changeme",
   "mote123",
   "password",
@@ -36,7 +42,7 @@ const TOKEN_DENYLIST = new Set([
   "admin",
   "test",
   "example",
-]);
+];
 const TOKEN_MIN_LENGTH = 32;
 
 function validateToken(token: string | undefined): string {
@@ -48,9 +54,10 @@ function validateToken(token: string | undefined): string {
       `MOTE_A2A_TOKEN must be at least ${TOKEN_MIN_LENGTH} characters (got ${token.length})`,
     );
   }
-  if (TOKEN_DENYLIST.has(token.toLowerCase())) {
+  const lower = token.toLowerCase();
+  if (TOKEN_DENYLIST_SUBSTRINGS.some(s => lower.includes(s))) {
     throw new Error(
-      "MOTE_A2A_TOKEN matches an obvious-weak denylist value; pick a stronger token",
+      "MOTE_A2A_TOKEN contains a denylisted substring; pick a stronger token",
     );
   }
   return token;
@@ -90,11 +97,12 @@ function buildPublicRegistry(
 
 function buildAgentCard(
   publicSkills: ReadonlyArray<LoadedSkill>,
+  agentCardUrl?: string,
 ): AgentCard {
   return {
     name: "mote",
     description: "Minimal personal AI agent",
-    url: process.env["MOTE_A2A_URL"] ?? "http://localhost:8787",
+    url: agentCardUrl ?? process.env["MOTE_A2A_URL"] ?? "http://localhost:8787",
     version: "0.1.0",
     capabilities: { streaming: true },
     defaultInputModes: ["text/plain"],
@@ -109,11 +117,14 @@ function buildAgentCard(
   };
 }
 
-// requestLogger that sets a context flag so downstream loggers know to
-// redact the Authorization header value (ADR-0011 D3).
-function buildLogRedactor() {
+// Mutates the raw request's Authorization header to "Bearer <redacted>" before
+// next() runs so that any downstream logger (hono/logger, custom middleware)
+// cannot observe the actual token value (ADR-0011 D3). Exported as a test seam.
+export function buildLogRedactor() {
   return async (c: Context, next: () => Promise<void>) => {
-    c.set("redact-auth", true);
+    if (c.req.raw.headers.has("authorization")) {
+      c.req.raw.headers.set("authorization", "Bearer <redacted>");
+    }
     await next();
   };
 }
@@ -121,11 +132,13 @@ function buildLogRedactor() {
 export function createA2aApp(ctx: AgentContext, opts: CreateA2aAppOpts): Hono {
   const token = validateToken(opts.token ?? process.env["MOTE_A2A_TOKEN"]);
   const maxBodySize = opts.maxBodySize ?? 100 * 1024;
-  const model = process.env["LLM_MODEL"] ?? "claude-sonnet-4-6";
+  // Prefer caller-supplied model over env var so Workers can pass it directly
+  // without mutating process.env (M2 / TOCTOU fix).
+  const model = opts.model ?? process.env["LLM_MODEL"] ?? "claude-sonnet-4-6";
 
   const publicSkills = opts.skills.filter(s => s.mcp === "public");
   const restrictedRegistry = buildPublicRegistry(publicSkills, model);
-  const agentCard = buildAgentCard(publicSkills);
+  const agentCard = buildAgentCard(publicSkills, opts.agentCardUrl);
 
   const userBuilder: UserBuilder = async (c) => {
     const headerValue = c.req.header("authorization") ?? "";
@@ -140,15 +153,20 @@ export function createA2aApp(ctx: AgentContext, opts: CreateA2aAppOpts): Hono {
     return { isAuthenticated: true, userName: "operator" };
   };
 
-  // Authentication enforcement middleware. The JSON-RPC endpoint (POST /)
-  // requires a valid Bearer token. The agent card (GET /.well-known/…) is
-  // public and intentionally skipped here.
+  // Authentication enforcement middleware. All routes require a valid Bearer
+  // token EXCEPT the public agent card endpoint. Using an allowlist (permit
+  // one specific route) rather than a denylist (block one specific route)
+  // ensures path-normalization variants like POST // or POST /%2F are covered
+  // structurally rather than relying on Hono's normalization behavior.
   // hono-a2a's userBuilder alone is not sufficient for rejection — it only
   // passes user info to ServerCallContext; the transport layer does not
   // gate on isAuthenticated. We enforce it at the Hono middleware layer.
   const authMiddleware = async (c: Context, next: () => Promise<void>) => {
-    // Only protect the JSON-RPC endpoint
-    if (c.req.method === "POST" && c.req.path === "/") {
+    // Allow unauthenticated access only to the agent card discovery endpoint.
+    const isAgentCard =
+      c.req.method === "GET" &&
+      c.req.path === "/.well-known/agent-card.json";
+    if (!isAgentCard) {
       const headerValue = c.req.header("authorization") ?? "";
       const presented = headerValue.replace(/^Bearer\s+/i, "").trim();
       if (!tokensEqual(presented, token)) {

--- a/src/entry/a2a-worker.ts
+++ b/src/entry/a2a-worker.ts
@@ -53,19 +53,16 @@ interface Env {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    // Inject env vars into process.env so existing code that reads
-    // process.env continues to work in the Worker.
-    if (env.MOTE_A2A_TOKEN) process.env["MOTE_A2A_TOKEN"] = env.MOTE_A2A_TOKEN;
-    if (env.LLM_API_KEY) process.env["LLM_API_KEY"] = env.LLM_API_KEY;
-    if (env.LLM_PROVIDER) process.env["LLM_PROVIDER"] = env.LLM_PROVIDER;
-    if (env.LLM_MODEL) process.env["LLM_MODEL"] = env.LLM_MODEL;
-    if (env.LLM_BASE_URL) process.env["LLM_BASE_URL"] = env.LLM_BASE_URL;
-    if (env.MOTE_A2A_URL) process.env["MOTE_A2A_URL"] = env.MOTE_A2A_URL;
-
+    // Build the provider using env bindings directly. Do NOT write to
+    // process.env — Cloudflare Workers share the global namespace across
+    // concurrent requests in the same isolate, creating a TOCTOU race (M2).
     const provider =
       (env.LLM_PROVIDER ?? "anthropic") === "openai-compat"
-        ? createOpenAICompatProvider()
-        : createAnthropicProvider();
+        ? createOpenAICompatProvider({
+            apiKey: env.LLM_API_KEY,
+            baseURL: env.LLM_BASE_URL,
+          })
+        : createAnthropicProvider({ apiKey: env.LLM_API_KEY });
 
     const ctx: AgentContext = {
       agentId: "default",
@@ -86,6 +83,9 @@ export default {
     const app = createA2aApp(ctx, {
       skills: [],
       taskStore: new InMemoryTaskStore(),
+      token: env.MOTE_A2A_TOKEN,
+      model: env.LLM_MODEL,
+      agentCardUrl: env.MOTE_A2A_URL,
       maxBodySize: env.MOTE_A2A_MAX_BODY
         ? parseInt(env.MOTE_A2A_MAX_BODY, 10)
         : undefined,

--- a/tests/channels/a2a.test.ts
+++ b/tests/channels/a2a.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createA2aApp } from "@/channels/a2a";
+import { createA2aApp, buildLogRedactor } from "@/channels/a2a";
 import { SqliteState } from "@/core/state";
 import { ensureWorkspace } from "@/core/workspace";
 import { ToolRegistry } from "@/core/registry";
@@ -75,33 +75,26 @@ test("createA2aApp throws when token is too short", () => {
   ).toThrow(/at least 32 characters/);
 });
 
-test("createA2aApp throws on exact denylist token (case-insensitive)", () => {
-  // A token that is exactly "changeme" in lowercase — padded to 32 chars
-  // it is no longer on the denylist because toLowerCase("changemeXXXXXXXXXXXXXX")
-  // !== "changeme". The denylist check is for exact match after toLowerCase.
-  // So we test with an exact 32-char string whose lowercase is still on the list.
-  // Note: "changeme" is only 8 chars so we cannot pad it to 32 and still match.
-  // Instead, test that the exact short denylist word throws for < 32 chars (short path):
+test("createA2aApp throws on token containing a denylist substring (case-insensitive)", () => {
+  // Short token: still fails on length check
   expect(() =>
     createA2aApp(stubCtx(workspaceDir, state), {
       skills: [],
       taskStore: state.a2aTaskStore,
       token: "password",
     }),
-  ).toThrow(); // throws for length < 32, regardless of denylist
+  ).toThrow(); // throws for length < 32
 
-  // Verify that the denylist message appears when the token is exactly a denylist word
-  // but meets the length requirement — this requires a word that is exactly 32 chars.
-  // None of the denylist words are 32 chars, so we test via the shorter path above.
-  // Additional assertion: a padded token that starts with "changeme" is NOT denied.
-  const paddedNonDenylist = "changeme".padEnd(32, "X");
+  // A token padded to 32 chars that CONTAINS "changeme" now also throws
+  // because the denylist uses substring matching (M1 fix).
+  const paddedWithDenylistSubstring = "changeme".padEnd(32, "X");
   expect(() =>
     createA2aApp(stubCtx(workspaceDir, state), {
       skills: [],
       taskStore: state.a2aTaskStore,
-      token: paddedNonDenylist,
+      token: paddedWithDenylistSubstring,
     }),
-  ).not.toThrow();
+  ).toThrow(/denylist/i);
 });
 
 test("createA2aApp accepts a strong token and returns a Hono app", () => {
@@ -170,7 +163,7 @@ test("JSON-RPC requests without Authorization header are rejected", async () => 
 // Token redaction canary: the bearer token must NEVER appear in any
 // error response body (ADR-0011 D3).
 test("REGRESSION: bearer token never appears in error response bodies", async () => {
-  const CANARY = "CANARY-TOKEN-DO-NOT-LEAK-1234567890abcd"; // 40 chars
+  const CANARY = "CANARY-DO-NOT-LEAK-1234567890abcdefghij"; // 40 chars, no denylist substring
   const app = createA2aApp(stubCtx(workspaceDir, state), {
     skills: [],
     taskStore: state.a2aTaskStore,
@@ -187,4 +180,141 @@ test("REGRESSION: bearer token never appears in error response bodies", async ()
   });
   const body = await res.text();
   expect(body).not.toContain(CANARY);
+});
+
+// ── F2: buildLogRedactor must actually mutate the Authorization header ──────
+
+test("F2: buildLogRedactor replaces Authorization header with Bearer <redacted>", async () => {
+  const TOKEN = "x".repeat(32);
+  const capturedHeaders: Headers[] = [];
+
+  // Build a minimal mock Hono Context with a mutable Headers object.
+  const mutableHeaders = new Headers({ authorization: `Bearer ${TOKEN}` });
+  const mockCtx = {
+    req: {
+      raw: {
+        headers: mutableHeaders,
+      },
+    },
+    set: () => {},
+  } as unknown as import("hono").Context;
+
+  const middleware = buildLogRedactor();
+  await middleware(mockCtx, async () => {
+    capturedHeaders.push(mockCtx.req.raw.headers);
+  });
+
+  expect(capturedHeaders.length).toBe(1);
+  const authValue = capturedHeaders[0]?.get("authorization");
+  expect(authValue).toBe("Bearer <redacted>");
+  expect(authValue).not.toContain(TOKEN);
+});
+
+// ── F8: authMiddleware must use allowlist (protect all except agent card) ────
+
+test("F8: rejects unauthenticated POST // (path-normalization bypass attempt)", async () => {
+  const app = createA2aApp(stubCtx(workspaceDir, state), {
+    skills: [],
+    taskStore: state.a2aTaskStore,
+    token: STRONG_TOKEN,
+  });
+  const res = await app.request("//", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  expect(res.status).toBe(401);
+});
+
+test("F8: rejects unauthenticated GET /v1/something (any non-agent-card route)", async () => {
+  const app = createA2aApp(stubCtx(workspaceDir, state), {
+    skills: [],
+    taskStore: state.a2aTaskStore,
+    token: STRONG_TOKEN,
+  });
+  const res = await app.request("/v1/something", {
+    method: "GET",
+  });
+  expect(res.status).toBe(401);
+});
+
+test("F8: permits unauthenticated GET /.well-known/agent-card.json (already passed, stays green)", async () => {
+  const app = createA2aApp(stubCtx(workspaceDir, state), {
+    skills: [],
+    taskStore: state.a2aTaskStore,
+    token: STRONG_TOKEN,
+  });
+  const res = await app.request("/.well-known/agent-card.json");
+  expect(res.status).toBe(200);
+});
+
+// ── M1: TOKEN_DENYLIST must use substring match ──────────────────────────────
+
+test("M1: rejects MOTE_A2A_TOKEN that contains a denylisted substring at length 32+", () => {
+  // "testtesttesttesttesttesttesttest" is 32 chars and contains "test"
+  expect(() =>
+    createA2aApp(stubCtx(workspaceDir, state), {
+      skills: [],
+      taskStore: state.a2aTaskStore,
+      token: "testtesttesttesttesttesttesttest",
+    }),
+  ).toThrow(/denylist/i);
+});
+
+test("M1: rejects MOTE_A2A_TOKEN that contains 'changeme' as a substring", () => {
+  // 32+ chars, contains "changeme"
+  expect(() =>
+    createA2aApp(stubCtx(workspaceDir, state), {
+      skills: [],
+      taskStore: state.a2aTaskStore,
+      token: "changeme1234567890123456789012345",
+    }),
+  ).toThrow(/denylist/i);
+});
+
+test("M1: accepts a 32+ char token that doesn't match any denylisted substring", () => {
+  // Use a random-looking token with no denylist substrings
+  const safeToken = "Zq9mK2rX8vLpNw7bAcDe3FgHiJoUsY6T"; // 32 chars
+  expect(() =>
+    createA2aApp(stubCtx(workspaceDir, state), {
+      skills: [],
+      taskStore: state.a2aTaskStore,
+      token: safeToken,
+    }),
+  ).not.toThrow();
+});
+
+// ── M2: a2a-worker must not mutate process.env ───────────────────────────────
+
+test("M2: a2a-worker does not mutate process.env when handling a request", async () => {
+  const worker = await import("@/entry/a2a-worker");
+
+  // Save exact env state before the call.
+  const keysBefore = new Set(Object.keys(process.env));
+  const tokenBefore = process.env["MOTE_A2A_TOKEN"];
+  const modelBefore = process.env["LLM_MODEL"];
+  const apiKeyBefore = process.env["LLM_API_KEY"];
+
+  const env = {
+    MOTE_A2A_TOKEN: STRONG_TOKEN,
+    LLM_API_KEY: "sk-test-key-for-unit-test",
+    LLM_PROVIDER: "anthropic",
+    LLM_MODEL: "claude-sonnet-4-6",
+    LLM_BASE_URL: undefined,
+    MOTE_A2A_URL: "http://localhost:8787",
+    MOTE_A2A_MAX_BODY: undefined,
+  };
+
+  const req = new Request("http://localhost:8787/.well-known/agent-card.json");
+  await worker.default.fetch(req, env as Parameters<typeof worker.default.fetch>[1]);
+
+  // process.env must be bitwise identical to what it was before the call.
+  expect(process.env["MOTE_A2A_TOKEN"]).toBe(tokenBefore);
+  expect(process.env["LLM_MODEL"]).toBe(modelBefore);
+  expect(process.env["LLM_API_KEY"]).toBe(apiKeyBefore);
+  // No new keys added.
+  const keysAfter = new Set(Object.keys(process.env));
+  for (const key of keysAfter) {
+    expect(keysBefore.has(key)).toBe(true);
+  }
 });


### PR DESCRIPTION
## Summary

Pentest-driven hardening of the A2A endpoint surface (M4) — bundles **4 findings** because all four touch overlapping files (`src/channels/a2a.ts`, `src/entry/a2a-worker.ts`, `tests/channels/a2a.test.ts`).

- **F2 (HIGH)** — `buildLogRedactor` previously called `c.set("redact-auth", true)` with **no consumer** for the flag (`grep` confirms zero readers). ADR-0011 D3 promised the `Authorization` header is stripped before any logger sees it; the promise was hollow. Now actually mutates `c.req.raw.headers` to `Bearer <redacted>` before `next()`, so any future `hono/logger` addition cannot leak the token.
- **F8 (HIGH)** — `authMiddleware` switched from **denylist** (`POST /` only) to **allowlist** (require auth except `GET /.well-known/agent-card.json`). Closes path-normalization bypass attempts (`POST //`, `POST /%2F`, …) and is structurally robust against future Hono normalization changes.
- **M1 (MEDIUM)** — `TOKEN_DENYLIST` was `Set<string>` of 4–8-char values, all pre-rejected by the 32-char min. 32-char tokens like `testtesttesttesttesttesttesttest` slipped through. Switched to substring match via `.toLowerCase().includes(...)`.
- **M2 (MEDIUM)** — `a2a-worker.ts` no longer mutates `process.env`; `CreateA2aAppOpts` now accepts `model`/`agentCardUrl` directly, avoiding the Workers isolate TOCTOU on shared globals.

References: ADR-0010, ADR-0011 D3 + D2, pentest report 2026-05-03 (F2, F8, M1, M2).

## Test plan

- [x] `bun test tests/channels/a2a.test.ts` — 8 → 16 (+8 tests covering each fix's contract)
- [x] `bun test` — full suite green
- [x] `bunx tsc --noEmit` — clean
- [x] Canary regression: token never appears in any error / log / response
- [ ] Manual smoke: deploy to Cloudflare Workers and verify auth + redaction in production env
