### PR TITLE
fix(skills): deduct sub-call budget + fence output as <skill-output>

### DIFF
--- a/src/skills/handler.ts
+++ b/src/skills/handler.ts
@@ -12,14 +12,24 @@ export interface SkillToolOpts {
   readonly maxTokens?: number;
 }
 
+// Wraps untrusted sub-LLM output in a structural fence (ADR-0014 D3).
+// The skill name is taken from the trusted LoadedSkill.name; the body is
+// the untrusted sub-call output. The fence is a defense-in-depth signal —
+// it makes the parent LLM less likely to confuse sub-call output for a
+// trusted tool report. No escaping inside the body is required per ADR-0014.
+function formatSkillOutput(skillName: string, texts: string[]): string {
+  const body = texts.join("") || "(skill produced no text output)";
+  return `<skill-output skill="${skillName}">\n${body}\n</skill-output>`;
+}
+
 // Builds a ToolDefinition from a parsed SKILL.md. The handler runs a
 // single, isolated LLM call:
 //   - skill.body becomes the `system` prompt
 //   - the LLM-supplied args become a JSON user message
 //   - tools=[] so the skill cannot recurse into the registry (M1
 //     keeps skills as single-call actions)
-// The assistant's text-block content is concatenated and returned as
-// the tool result.
+// The assistant's text-block content is concatenated, fenced, and returned
+// as the tool result.
 export function createSkillToolDefinition(
   skill: LoadedSkill,
   opts: SkillToolOpts,
@@ -33,6 +43,10 @@ export function createSkillToolDefinition(
     description: skill.description,
     schema: SkillArgs,
     handler: async (args, ctx) => {
+      // Pre-check per ADR-0015 D2: budget exhausted → error string, do not call provider.
+      if (ctx.opts.budget.remaining <= 0) {
+        return "[error] iteration budget exhausted; skill not dispatched";
+      }
       const argsText =
         Object.keys(args).length > 0
           ? `Arguments:\n${JSON.stringify(args, null, 2)}`
@@ -49,14 +63,14 @@ export function createSkillToolDefinition(
         ],
         tools: [],
       });
+      // ADR-0015 D1: deduct sub-call usage from the outer iteration budget.
+      ctx.opts.budget.deduct(res.usage);
       const texts: string[] = [];
       for (const block of res.assistant.content) {
         if (block.type === "text") texts.push(block.text);
       }
-      // Budget deduction is intentionally NOT done here — the sub-call
-      // is invisible to the outer iteration budget in M1. M2 can revisit
-      // when usage tracking matures.
-      return texts.join("") || "(skill produced no text output)";
+      // ADR-0014 D3: fence untrusted sub-LLM output before returning as tool_result.
+      return formatSkillOutput(skill.name, texts);
     },
   };
 }

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -179,7 +179,7 @@ test("invoke_skill dispatches a public skill through the registry", async () => 
     name: "echo-skill",
     args: {},
   });
-  expect(out).toBe("skill-output");
+  expect(out).toBe('<skill-output skill="echo-skill">\nskill-output\n</skill-output>');
 });
 
 test("search_sessions returns 'No matches' for an empty corpus", async () => {

--- a/tests/skills/handler.test.ts
+++ b/tests/skills/handler.test.ts
@@ -1,8 +1,9 @@
-import { test, expect } from "bun:test";
+import { test, expect, describe, it } from "bun:test";
 import { createSkillToolDefinition } from "@/skills/handler";
 import type { LoadedSkill } from "@/skills/types";
 import type { Provider } from "@/providers/types";
 import type { AgentContext } from "@/core/context";
+import type { IterationBudget, Usage } from "@/core/types";
 
 const skill: LoadedSkill = {
   name: "hello",
@@ -69,7 +70,7 @@ test("handler sends skill.body as system, args as a user message, and no tools",
   const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
   const result = await def.handler({ greeting: "hi" }, stubCtx(provider));
 
-  expect(result).toBe("hi from skill");
+  expect(result).toBe('<skill-output skill="hello">\nhi from skill\n</skill-output>');
   expect(captured.system).toBe("Reply with the literal text 'hi from skill'.");
   expect(captured.tools).toEqual([]);
   expect(captured.model).toBe("claude-sonnet-4-6");
@@ -89,7 +90,7 @@ test("handler returns a placeholder string when the skill produces no text", asy
   };
   const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
   const result = await def.handler({}, stubCtx(provider));
-  expect(result).toBe("(skill produced no text output)");
+  expect(result).toBe('<skill-output skill="hello">\n(skill produced no text output)\n</skill-output>');
 });
 
 test("handler concatenates multiple text blocks", async () => {
@@ -110,7 +111,7 @@ test("handler concatenates multiple text blocks", async () => {
   };
   const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
   const result = await def.handler({}, stubCtx(provider));
-  expect(result).toBe("part 1 part 2");
+  expect(result).toBe('<skill-output skill="hello">\npart 1 part 2\n</skill-output>');
 });
 
 test("handler uses generic prompt when args is empty", async () => {
@@ -132,4 +133,129 @@ test("handler uses generic prompt when args is empty", async () => {
   const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
   await def.handler({}, stubCtx(provider));
   expect(captured.messages[0].content[0].text).toBe("Execute the skill.");
+});
+
+// ── Helpers for F3/F5 tests ──────────────────────────────────────────────────
+
+function makeTrackingBudget(initialRemaining: number): IterationBudget & { calls: Usage[] } {
+  const calls: Usage[] = [];
+  let remaining = initialRemaining;
+  return {
+    get remaining() { return remaining; },
+    deduct(usage: Usage) {
+      remaining -= usage.input + usage.output;
+      calls.push(usage);
+    },
+    calls,
+  };
+}
+
+function stubCtxWithBudget(provider: Provider, budget: IterationBudget): AgentContext {
+  return {
+    agentId: "default",
+    sessionId: "s_test",
+    workspaceDir: "/tmp/test",
+    registry: {} as AgentContext["registry"],
+    provider,
+    state: {
+      async appendMessages(_s: string, _m: unknown[]) {},
+      async loadLatestSession() { return []; },
+      async searchSessions(_q: string, _l?: number) { return []; },
+      async listSessions() { return []; },
+      async getSession(_id: string, _limit: number) { return { messages: [], truncated: false }; },
+    },
+    opts: {
+      maxIterations: 5,
+      budget,
+    },
+    signal: new AbortController().signal,
+    systemPrompt: () => "irrelevant",
+  } as AgentContext;
+}
+
+// ── F3: budget deduct + pre-check ─────────────────────────────────────────────
+
+describe("createSkillToolDefinition — F3 budget", () => {
+  it("calls ctx.opts.budget.deduct after a successful sub-call", async () => {
+    const budget = makeTrackingBudget(1000);
+    const provider: Provider = {
+      complete: async () => ({
+        assistant: { role: "assistant", content: [{ type: "text", text: "ok" }], createdAt: 0 },
+        toolCalls: [],
+        usage: { input: 100, output: 50 },
+      }),
+    };
+    const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
+    await def.handler({}, stubCtxWithBudget(provider, budget));
+    expect(budget.calls).toHaveLength(1);
+    expect(budget.calls[0]).toEqual({ input: 100, output: 50 });
+    expect(budget.remaining).toBe(850);
+  });
+
+  it("returns [error] when budget.remaining <= 0 without invoking provider", async () => {
+    const budget = makeTrackingBudget(0);
+    let providerCalled = false;
+    const provider: Provider = {
+      complete: async () => {
+        providerCalled = true;
+        throw new Error("provider should not be called");
+      },
+    };
+    const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
+    const result = await def.handler({}, stubCtxWithBudget(provider, budget));
+    expect(typeof result).toBe("string");
+    expect((result as string).startsWith("[error]")).toBe(true);
+    expect(providerCalled).toBe(false);
+  });
+});
+
+// ── F5: output fence ──────────────────────────────────────────────────────────
+
+describe("createSkillToolDefinition — F5 fence", () => {
+  it('wraps the joined assistant text in <skill-output skill="name">', async () => {
+    const budget = makeTrackingBudget(1000);
+    const provider: Provider = {
+      complete: async () => ({
+        assistant: { role: "assistant", content: [{ type: "text", text: "hello world" }], createdAt: 0 },
+        toolCalls: [],
+        usage: { input: 1, output: 1 },
+      }),
+    };
+    const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
+    const result = await def.handler({}, stubCtxWithBudget(provider, budget));
+    expect(result).toBe('<skill-output skill="hello">\nhello world\n</skill-output>');
+  });
+
+  it("uses the skill's own name in the fence (taken from LoadedSkill, not args)", async () => {
+    const budget = makeTrackingBudget(1000);
+    const provider: Provider = {
+      complete: async () => ({
+        assistant: { role: "assistant", content: [{ type: "text", text: "output" }], createdAt: 0 },
+        toolCalls: [],
+        usage: { input: 1, output: 1 },
+      }),
+    };
+    const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
+    // Pass an arg that could be confused for a skill name if the handler incorrectly used it
+    const result = await def.handler({ skill: "evil" }, stubCtxWithBudget(provider, budget));
+    // skill.name is "hello" — must appear in the fence, not "evil"
+    expect((result as string)).toContain('skill="hello"');
+    expect((result as string)).not.toContain('skill="evil"');
+  });
+
+  it("preserves the no-output fallback message inside the fence", async () => {
+    const budget = makeTrackingBudget(1000);
+    const provider: Provider = {
+      complete: async () => ({
+        assistant: { role: "assistant", content: [], createdAt: 0 },
+        toolCalls: [],
+        usage: { input: 1, output: 0 },
+      }),
+    };
+    const def = createSkillToolDefinition(skill, { model: "claude-sonnet-4-6" });
+    const result = await def.handler({}, stubCtxWithBudget(provider, budget));
+    expect(result).toBe(
+      '<skill-output skill="hello">\n(skill produced no text output)\n</skill-output>',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Pentest-driven hardening of the skill execution surface — **2 findings** in `src/skills/handler.ts`.

- **F3 (HIGH, ADR-0015 D1+D2)** — skill sub-call inside `createSkillToolDefinition` did NOT call `ctx.opts.budget.deduct(res.usage)`. A comment at handler.ts:56-58 admitted this. Cost-DoS: an attacker influencing a `mcp: public` skill body (FS access OR a future skill-marketplace channel) plus prompt-injecting the parent to invoke that skill repeatedly drains the operator's API balance unbounded. Now: pre-check `budget.remaining <= 0` and return error string per the `ToolHandler` contract; deduct after every sub-completion.
- **F5 (HIGH, ADR-0014 D3)** — skill sub-call output was joined and returned as `tool_result` without a fence. Sub-LLM (running with attacker-influenced skill body as system) could produce text the parent LLM mistook for trusted tool report (`Done. Updated memory.`). Now: wrapped in `<skill-output skill="{LoadedSkill.name}">…</skill-output>`. Skill name is trusted (operator-installed), body is the untrusted sub-call output.

References: ADR-0014 D3, ADR-0015 D1+D2, pentest report 2026-05-03 (F3, F5, D4-HIGH-1, D4-HIGH-3 — F3 was independently flagged by D3 and D4 reviewers).

## Test plan

- [x] `bun test tests/skills/handler.test.ts` — 5 new tests (F3: budget deduct + pre-check; F5: fence shape, skill-name attribution, no-output fallback)
- [x] `bun test` — 320 → 325 pass, full suite green
- [x] `bunx tsc --noEmit` — clean
- [x] Cascading update to `tests/mcp/server.test.ts` (1 assertion) because `invoke_skill` delegates to `createSkillToolDefinition` and the F5 fence applies there too
