### PR TITLE
fix(pairing): dedup pending entries per userId

### DIFF
--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -27,18 +27,26 @@ export function createPairingStore(
   const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
   const clock = opts.clock ?? (() => Date.now());
   const pending = new Map<string, PendingPairing>();
+  const byUser = new Map<number, string>();
 
   return {
     generate(userId) {
+      const oldCode = byUser.get(userId);
+      if (oldCode !== undefined) {
+        pending.delete(oldCode);
+        byUser.delete(userId);
+      }
       const code = randomBytes(16).toString("hex");
       const entry: PendingPairing = { code, userId, expiresAt: clock() + ttlMs };
       pending.set(code, entry);
+      byUser.set(userId, code);
       return entry;
     },
     redeem(code) {
       const entry = pending.get(code);
       if (!entry) return { ok: false, reason: "not_found" };
       pending.delete(code);
+      byUser.delete(entry.userId);
       if (clock() >= entry.expiresAt) return { ok: false, reason: "expired" };
       return { ok: true, userId: entry.userId };
     },
@@ -48,6 +56,7 @@ export function createPairingStore(
       for (const [code, entry] of pending) {
         if (t >= entry.expiresAt) {
           pending.delete(code);
+          byUser.delete(entry.userId);
           removed += 1;
         }
       }

--- a/tests/channels/telegram-pairing.test.ts
+++ b/tests/channels/telegram-pairing.test.ts
@@ -70,4 +70,45 @@ describe("createPairingStore", () => {
     const p = store.generate(99);
     expect(p.expiresAt).toBe(150);
   });
+
+  it("generate() for the same userId twice keeps only the latest entry in the pending map", () => {
+    const store = createPairingStore();
+    const a = store.generate(7);
+    const b = store.generate(7);
+    expect(a.code).not.toBe(b.code);
+    // The first code is no longer redeemable
+    expect(store.redeem(a.code)).toEqual({ ok: false, reason: "not_found" });
+    // The second code IS redeemable
+    expect(store.redeem(b.code)).toEqual({ ok: true, userId: 7 });
+  });
+
+  it("generate() does not affect entries for other userIds", () => {
+    const store = createPairingStore();
+    const u1 = store.generate(1);
+    const u2 = store.generate(2);
+    store.generate(1); // re-issue for user 1
+    expect(store.redeem(u2.code)).toEqual({ ok: true, userId: 2 });
+  });
+
+  it("redeem() removes both forward and reverse index entries", () => {
+    const store = createPairingStore();
+    const a = store.generate(11);
+    expect(store.redeem(a.code)).toEqual({ ok: true, userId: 11 });
+    // Issuing a fresh code for the same user should not collide
+    const b = store.generate(11);
+    expect(b.code).not.toBe(a.code);
+    expect(store.redeem(b.code)).toEqual({ ok: true, userId: 11 });
+  });
+
+  it("sweep() removes the reverse index entry for expired codes", () => {
+    let now = 0;
+    const store = createPairingStore({ ttlMs: 1000, clock: () => now });
+    store.generate(99);
+    now = 2000;
+    expect(store.sweep()).toBe(1);
+    // After sweep, generate() for the same user issues a fresh code (no leak)
+    const fresh = store.generate(99);
+    now = 2500;
+    expect(store.redeem(fresh.code)).toEqual({ ok: true, userId: 99 });
+  });
 });


### PR DESCRIPTION
## Summary

Pentest finding **F4 (HIGH)** — `src/channels/telegram-pairing.ts` `generate(userId)` did not remove prior entries for the same `userId`. An unauthorized Telegram user DMing the bot N times caused N pending entries to accumulate (memory exhaustion) and N notifications to the master (UX DoS / spam). 24h TTL meant `sweep()` did not contain the storm.

Fix: maintain a `byUser: Map<number, string>` reverse index. On `generate()`, remove the prior entry for the same user before inserting the new one. `redeem()` and `sweep()` keep both maps in sync.

Per-user state is now always at most one pending code, regardless of inbound DM rate.

References: ADR-0012 D4, pentest report 2026-05-03 (F4).

## Test plan

- [x] `bun test tests/channels/telegram-pairing.test.ts` — 13 → 17 (+4 tests):
  - `generate()` for the same userId twice keeps only the latest
  - `generate()` does not affect entries for other userIds
  - `redeem()` removes both forward and reverse index entries
  - `sweep()` removes the reverse index entry for expired codes
- [x] `bun test` — full suite green (324 pass)
- [x] `bunx tsc --noEmit` — clean
