### PR TITLE
fix(memory): neutralize $-pattern interpretation in memory_edit replace

### DIFF
--- a/src/core/tools/memory.ts
+++ b/src/core/tools/memory.ts
@@ -69,7 +69,7 @@ export const memoryEditTool: ToolDefinition<typeof EditArgs> = {
     if (occurrences > 1) {
       return `[error] memory_edit: \`find\` appears ${occurrences} times; pass a longer substring that uniquely identifies the target.`;
     }
-    const next = existing.replace(args.find, args.replace);
+    const next = existing.replace(args.find, () => args.replace);
     try {
       await writeFile(path, next + "\n", { mode: 0o600 });
       await chmod(path, 0o600);

--- a/tests/core/tools/memory.test.ts
+++ b/tests/core/tools/memory.test.ts
@@ -191,3 +191,52 @@ test("memory_append accepts a single newline (whitespace-only) and writes it as-
   const content = await readFile(join(workspaceDir, "MEMORY.md"), "utf8");
   expect(content.length).toBeGreaterThan(0);
 });
+
+// --- security: $ pattern neutralization in memory_edit -------------------
+
+test("memory_edit treats `$&` in replace as a literal, not as the matched substring", async () => {
+  await memoryAppendTool.handler({ text: "abc" }, ctx);
+  const result = await memoryEditTool.handler(
+    { find: "abc", replace: "$& - $&" },
+    ctx,
+  );
+  expect(result).toMatch(/^Replaced/);
+  const content = await readFile(join(workspaceDir, "MEMORY.md"), "utf8");
+  // Must be the literal string "$& - $&", NOT "abc - abc".
+  expect(content).toBe("$& - $&\n");
+});
+
+test("memory_edit treats `$$` in replace as a literal", async () => {
+  await memoryAppendTool.handler({ text: "x" }, ctx);
+  const result = await memoryEditTool.handler(
+    { find: "x", replace: "$$y" },
+    ctx,
+  );
+  expect(result).toMatch(/^Replaced/);
+  const content = await readFile(join(workspaceDir, "MEMORY.md"), "utf8");
+  // Must be the literal string "$$y", NOT "$y".
+  expect(content).toBe("$$y\n");
+});
+
+test("memory_edit treats `$'` in replace as a literal", async () => {
+  await memoryAppendTool.handler({ text: "abcDEF" }, ctx);
+  const result = await memoryEditTool.handler(
+    { find: "abc", replace: "[$'rest]" },
+    ctx,
+  );
+  expect(result).toMatch(/^Replaced/);
+  const content = await readFile(join(workspaceDir, "MEMORY.md"), "utf8");
+  // Must be the literal string "[$'rest]DEF", NOT the post-match substring.
+  expect(content).toBe("[$'rest]DEF\n");
+});
+
+test("memory_edit normal case (no $ patterns) still works", async () => {
+  await memoryAppendTool.handler({ text: "old value" }, ctx);
+  const result = await memoryEditTool.handler(
+    { find: "old", replace: "new" },
+    ctx,
+  );
+  expect(result).toMatch(/^Replaced/);
+  const content = await readFile(join(workspaceDir, "MEMORY.md"), "utf8");
+  expect(content).toBe("new value\n");
+});


### PR DESCRIPTION
## Summary

Pentest finding **F1 (HIGH)** — `src/core/tools/memory.ts:72`:

```ts
const next = existing.replace(args.find, args.replace);
```

`String.prototype.replace(string, string)` interprets `$&`, `` $` ``, `$'`, `$$`, `$<n>` as pattern references in the second argument. A prompt-injection attacker invoking `memory_edit({ find: "secret", replace: "$& - $& - $&" })` caused MEMORY.md to be rewritten as `secret - secret - secret` — content smuggling through the find/replace contract.

Fix: switch to the function form of replace, which does not interpret `$` patterns:

```ts
const next = existing.replace(args.find, () => args.replace);
```

One-line source change. Tests bear the bulk of the diff.

References: pentest report 2026-05-03 (F1).

## Test plan

- [x] `bun test tests/core/tools/memory.test.ts` — +4 new tests:
  - `$&` treated as literal (not match-all-substring expansion)
  - `$$` treated as literal
  - `$'` treated as literal (not post-match expansion)
  - sanity: normal find/replace still works
- [x] `bun test` — full suite green (324 pass)
- [x] `bunx tsc --noEmit` — clean
- [x] Red confirmed: 3 pattern tests failed before the fix with the exact pentest-described expansions; sanity test was already green (test infrastructure not blanket-broken)
