### PR TITLE
fix(state, mcp): cap list_sessions and get_session limits

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -23,7 +23,7 @@ export interface SessionState {
   loadLatestSession(): Promise<Message[]>;
   searchSessions(query: string, limit?: number): Promise<SearchHit[]>;
   // ADR-0009 D4: list and retrieve sessions for MCP tools
-  listSessions(): Promise<SessionMeta[]>;
+  listSessions(limit?: number): Promise<SessionMeta[]>;
   getSession(sessionId: string, limit: number): Promise<GetSessionResult>;
 }
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -259,15 +259,12 @@ export class SqliteState implements SessionState {
     }));
   }
 
-  async listSessions(): Promise<SessionMeta[]> {
+  async listSessions(limit = 100): Promise<SessionMeta[]> {
     const rows = this.db
-      .query<
-        { id: string; created_at: number; ended_at: number | null },
-        []
-      >(
-        "SELECT id, created_at, ended_at FROM sessions ORDER BY created_at DESC, id DESC",
+      .query<{ id: string; created_at: number; ended_at: number | null }, [number]>(
+        "SELECT id, created_at, ended_at FROM sessions ORDER BY created_at DESC, id DESC LIMIT ?",
       )
-      .all();
+      .all(limit);
     return rows.map(r => ({
       id: r.id,
       createdAt: r.created_at,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,11 +11,26 @@ import type { LoadedSkill } from "@/skills/types";
 
 // Resolves the per-call get_session cap from env, falling back to 200
 // per ADR-0009 D4. Re-read on every call so an operator can tweak the
-// env at runtime (e.g., for an interactive debug session).
-function getSessionLimit(): number {
+// env at runtime (e.g., for an interactive debug session). Hard upper
+// bound of 10 000 guards against env-injection memory exhaustion (M7).
+export function getSessionLimit(): number {
   const raw = process.env["MOTE_MCP_GET_SESSION_LIMIT"];
-  const parsed = raw === undefined ? NaN : parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 200;
+  if (!raw) return 200;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 200;
+  return Math.min(parsed, 10_000);
+}
+
+// Resolves the per-call list_sessions cap from env, falling back to
+// 100. Same env-override shape as getSessionLimit. Hard upper bound of
+// 10 000 prevents a high env value from materialising a massive result
+// set in memory (pentest finding F7 + M7).
+export function listSessionsLimit(): number {
+  const raw = process.env["MOTE_MCP_LIST_SESSIONS_LIMIT"];
+  if (!raw) return 100;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 100;
+  return Math.min(parsed, 10_000);
 }
 
 // One MCP-exposed tool. Schema is valibot (consistent with the agent
@@ -41,13 +56,14 @@ function buildTools(
 ): ReadonlyArray<McpTool> {
   const tools: McpTool[] = [];
 
-  // list_sessions — no args
+  // list_sessions — no args; capped at MOTE_MCP_LIST_SESSIONS_LIMIT (default 100)
   tools.push({
     name: "list_sessions",
-    description: "List session ids ordered by created_at (latest first).",
+    description: "List session ids ordered by created_at (latest first). Capped at MOTE_MCP_LIST_SESSIONS_LIMIT (default 100).",
     schema: v.object({}),
     handler: async () => {
-      const meta = await ctx.state.listSessions();
+      const limit = listSessionsLimit();
+      const meta = await ctx.state.listSessions(limit);
       if (meta.length === 0) return "(no sessions)";
       const lines = meta.map(
         m => `- ${m.id}  ${new Date(m.createdAt).toISOString()}`,

--- a/tests/core/state.test.ts
+++ b/tests/core/state.test.ts
@@ -197,6 +197,30 @@ test("listSessions returns [] when no sessions exist", async () => {
   expect(await state.listSessions()).toEqual([]);
 });
 
+test("listSessions returns at most `limit` rows ordered by created_at DESC", async () => {
+  const base = Date.now();
+  for (let i = 0; i < 150; i++) {
+    await state.appendMessages(`s_${i}`, [
+      { role: "user", content: [{ type: "text", text: `msg ${i}` }], createdAt: base + i },
+    ]);
+  }
+  const meta = await state.listSessions(50);
+  expect(meta).toHaveLength(50);
+  // First row should be the newest session (s_149)
+  expect(meta[0]?.id).toBe("s_149");
+});
+
+test("listSessions defaults to 100 rows when limit is omitted", async () => {
+  const base = Date.now();
+  for (let i = 0; i < 150; i++) {
+    await state.appendMessages(`s_lim_${i}`, [
+      { role: "user", content: [{ type: "text", text: `msg ${i}` }], createdAt: base + i },
+    ]);
+  }
+  const meta = await state.listSessions();
+  expect(meta).toHaveLength(100);
+});
+
 // --- getSession ----------------------------------------------------------
 
 test("getSession returns messages chronologically with truncated:false when count <= limit", async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createMoteMcpServer } from "@/mcp/server";
+import { createMoteMcpServer, listSessionsLimit, getSessionLimit } from "@/mcp/server";
 import { ToolRegistry } from "@/core/registry";
 import { SqliteState } from "@/core/state";
 import { ensureWorkspace } from "@/core/workspace";
@@ -198,4 +198,39 @@ test("list_skills returns '(no skills installed)' when empty", async () => {
   const { tools } = createMoteMcpServer(ctx, []);
   const out = await findTool(tools, "list_skills").handler({});
   expect(out).toBe("(no skills installed)");
+});
+
+test("list_sessions MCP tool defaults to 100 rows", async () => {
+  const base = Date.now();
+  for (let i = 0; i < 150; i++) {
+    await state.appendMessages(`s_mcp_${i}`, [
+      { role: "user", content: [{ type: "text", text: `msg ${i}` }], createdAt: base + i },
+    ]);
+  }
+  const { tools } = createMoteMcpServer(ctx, []);
+  const out = await findTool(tools, "list_sessions").handler({});
+  const lines = out.split("\n").filter((l: string) => l.startsWith("- "));
+  expect(lines).toHaveLength(100);
+});
+
+test("MOTE_MCP_LIST_SESSIONS_LIMIT env caps at 10000 even when set higher", () => {
+  const prev = process.env["MOTE_MCP_LIST_SESSIONS_LIMIT"];
+  process.env["MOTE_MCP_LIST_SESSIONS_LIMIT"] = "999999";
+  try {
+    expect(listSessionsLimit()).toBe(10_000);
+  } finally {
+    if (prev === undefined) delete process.env["MOTE_MCP_LIST_SESSIONS_LIMIT"];
+    else process.env["MOTE_MCP_LIST_SESSIONS_LIMIT"] = prev;
+  }
+});
+
+test("getSessionLimit also caps at 10000 (co-fix)", () => {
+  const prev = process.env["MOTE_MCP_GET_SESSION_LIMIT"];
+  process.env["MOTE_MCP_GET_SESSION_LIMIT"] = "999999";
+  try {
+    expect(getSessionLimit()).toBe(10_000);
+  } finally {
+    if (prev === undefined) delete process.env["MOTE_MCP_GET_SESSION_LIMIT"];
+    else process.env["MOTE_MCP_GET_SESSION_LIMIT"] = prev;
+  }
 });


### PR DESCRIPTION
## Summary

Pentest finding **F7 (HIGH)** — `SqliteState.listSessions()` returned ALL sessions with no `LIMIT`. The MCP `list_sessions` tool exposed this unbounded to the local client. Long-running operators accumulate thousands of sessions; one MCP call leaks the full timeline (info leak via session count + timestamps), and at very large counts pressures memory.

ADR-0009 D4 already capped `get_session` (default 200, env-overridable). Apply the same pattern to `list_sessions`.

**Plus co-fix for M7 (MEDIUM)**: both `getSessionLimit()` and the new `listSessionsLimit()` now apply a hard `Math.min(parsed, 10_000)` so an env value like `999999999` cannot cause SQLite to materialize a million-row result set.

Changes:
- `src/core/state.ts` — `listSessions(limit = 100)` now passes `LIMIT ?` through.
- `src/core/context.ts` — `SessionState` interface signature updated (one-line type-only change for TS correctness).
- `src/mcp/server.ts` — exported `listSessionsLimit()` mirrors `getSessionLimit()` shape with env override `MOTE_MCP_LIST_SESSIONS_LIMIT`; both helpers now hard-cap at 10000.

References: ADR-0009 D4, pentest report 2026-05-03 (F7, M7).

## Test plan

- [x] `bun test tests/core/state.test.ts tests/mcp/server.test.ts` — +5 new tests (limit param semantics, default 100, env cap at 10000 for both helpers)
- [x] `bun test` — 320 → 325 pass, full suite green
- [x] `bunx tsc --noEmit` — clean

## Note on overlap with `tests/mcp/server.test.ts`

PR #2 (skill budget+fence) also touches `tests/mcp/server.test.ts`. Conflict at merge time is possible — the second-merged PR may need a small rebase. Both changes are localized; resolution should be mechanical.
