### PR TITLE
fix(skills): confine loadSkills to workspaceDir/skills via realpath

### DIFF
--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
+import { join } from "node:path";
 import { Glob } from "bun";
 
 import { parseFrontmatter } from "@/skills/frontmatter";
@@ -18,10 +19,39 @@ import type { LoadedSkill } from "@/skills/types";
 // fine — a user may run mote with no skills installed yet.
 export async function loadSkills(workspaceDir: string): Promise<LoadedSkill[]> {
   const glob = new Glob("skills/*/SKILL.md");
-  const matches: string[] = [];
-  for await (const relPath of glob.scan({ cwd: workspaceDir, absolute: true })) {
-    matches.push(relPath);
+  const rawMatches: string[] = [];
+  for await (const absPath of glob.scan({ cwd: workspaceDir, absolute: true })) {
+    rawMatches.push(absPath);
   }
+
+  // ADR-0008 confinement: resolve each SKILL.md via realpath and verify the
+  // canonical path stays inside <workspaceDir>/skills/. This blocks
+  // symlinks that point outside the workspace (pentest finding M6).
+  // Both sides are canonicalized to handle macOS /var → /private/var.
+  let skillsRoot: string;
+  try {
+    skillsRoot = await realpath(join(workspaceDir, "skills"));
+  } catch {
+    // skills/ directory does not exist — nothing to load.
+    return [];
+  }
+
+  const matches: string[] = [];
+  for (const absPath of rawMatches) {
+    let resolved: string;
+    try {
+      resolved = await realpath(absPath);
+    } catch {
+      // Broken symlink or missing file — skip silently.
+      continue;
+    }
+    if (resolved !== skillsRoot && !resolved.startsWith(skillsRoot + "/")) {
+      console.warn(`[skills] skipping symlink-out-of-tree: ${absPath} → ${resolved}`);
+      continue;
+    }
+    matches.push(absPath);
+  }
+
   // Stable order so tests (and `list_skills` MCP tool in M3) see deterministic output.
   matches.sort();
 

--- a/tests/skills/loader.test.ts
+++ b/tests/skills/loader.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -125,4 +126,41 @@ test("loadSkills throws on a malformed skill positioned between two valid skills
   await writeSkill("broken", `---\nname: broken\nthis-line-has-no-colon\n---\nbody`);
   await writeSkill("gamma", `---\nname: gamma\ndescription: g\n---\nbody`);
   await expect(loadSkills(workspaceDir)).rejects.toThrow(/skill at .*broken.*SKILL\.md/);
+});
+
+// --- confinement: symlink traversal (pentest finding M6) ------------------
+
+test("loadSkills skips a SKILL.md whose realpath escapes the workspace via symlink", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mote-skill-symlink-"));
+  const outsideDir = mkdtempSync(join(tmpdir(), "mote-outside-"));
+  writeFileSync(
+    join(outsideDir, "evil.md"),
+    "---\nname: evil\ndescription: out\nmcp: public\n---\nbody",
+  );
+  // Create the in-tree skill dir but symlink SKILL.md to an outside file
+  mkdirSync(join(dir, "skills", "evil"), { recursive: true });
+  symlinkSync(join(outsideDir, "evil.md"), join(dir, "skills", "evil", "SKILL.md"));
+  const skills = await loadSkills(dir);
+  expect(skills.find((s) => s.name === "evil")).toBeUndefined();
+});
+
+test("loadSkills loads a normal in-tree skill correctly (regression)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mote-skill-normal-"));
+  mkdirSync(join(dir, "skills", "hello"), { recursive: true });
+  writeFileSync(
+    join(dir, "skills", "hello", "SKILL.md"),
+    "---\nname: hello\ndescription: greet\nmcp: public\n---\nbody",
+  );
+  const skills = await loadSkills(dir);
+  const hello = skills.find((s) => s.name === "hello");
+  expect(hello).toBeDefined();
+});
+
+test("loadSkills tolerates a broken symlink without crashing", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mote-skill-broken-"));
+  mkdirSync(join(dir, "skills", "broken"), { recursive: true });
+  // SKILL.md is a symlink pointing to a path that does not exist
+  symlinkSync("/nonexistent/path/SKILL.md", join(dir, "skills", "broken", "SKILL.md"));
+  const skills = await loadSkills(dir);
+  expect(Array.isArray(skills)).toBe(true);
 });


### PR DESCRIPTION
## Summary

Pentest finding **M6 (MEDIUM)** — `loadSkills()` (`src/skills/loader.ts`) used Bun's `Glob` with default symlink follow. ADR-0008 confinement applies to the `read_file` tool but NOT to `loadSkills`, which uses `readFile` directly. A `<workspaceDir>/skills/<name>/SKILL.md` symlink pointing outside the workspace would let the loader read arbitrary files.

Fix: resolve each `SKILL.md` candidate via `realpath` and skip any whose canonical path escapes `<workspaceDir>/skills/`. Broken symlinks are silently skipped so one bad entry does not block the rest. A `console.warn` surfaces skipped entries for operator visibility.

Mirrors the realpath + prefix-check idiom from `src/core/tools/read_file.ts` (ADR-0008).

**Attack vector clarification (from impl notes)**: Bun's `Glob` does NOT follow directory-level symlinks (`skills/evil → /outside/`), but DOES follow file-level symlinks (`skills/evil/SKILL.md → /outside/evil.md`). Tests use the file-level shape since that's what's actually exploitable.

References: ADR-0008, pentest report 2026-05-03 (M6).

## Test plan

- [x] `bun test tests/skills/loader.test.ts` — +3 new tests:
  - symlink-out-of-tree SKILL.md is NOT loaded
  - in-tree skills load normally (regression)
  - broken symlink doesn't crash the loader
- [x] `bun test` — full suite green (323 pass)
- [x] `bunx tsc --noEmit` — clean
- [x] Red confirmed: evil-skill test loaded the out-of-tree skill before the fix; now correctly skipped
