### PR TITLE
fix(providers): sanitize API key from anthropic catch fallback path

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -103,12 +103,19 @@ function buildAnthropicSystem(system: SystemPrompt): unknown[] | undefined {
   }));
 }
 
+function sanitizeError(msg: string, apiKey: string): string {
+  if (!apiKey) return msg;
+  return msg.split(apiKey).join("<redacted>");
+}
+
 export function createAnthropicProvider(opts: AnthropicProviderOpts = {}): Provider {
   const maxTokens = opts.maxTokens ?? 4096;
 
   let client: AnthropicLike;
+  let capturedApiKey = "";
   if (opts.client !== undefined) {
     client = opts.client;
+    capturedApiKey = opts.apiKey ?? "";
   } else {
     const apiKey =
       opts.apiKey ?? process.env["LLM_API_KEY"] ?? process.env["ANTHROPIC_API_KEY"];
@@ -117,6 +124,7 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts = {}): Provi
         "Anthropic API key required (set LLM_API_KEY or ANTHROPIC_API_KEY).",
       );
     }
+    capturedApiKey = apiKey;
     client = new Anthropic({ apiKey, baseURL: opts.baseURL });
   }
 
@@ -152,10 +160,11 @@ export function createAnthropicProvider(opts: AnthropicProviderOpts = {}): Provi
             "message" in e)
         ) {
           const apiErr = e as { status: unknown; message: unknown };
-          throw new Error(`anthropic ${apiErr.status}: ${apiErr.message}`);
+          const safeMsg = sanitizeError(String(apiErr.message), capturedApiKey);
+          throw new Error(`anthropic ${apiErr.status}: ${safeMsg}`);
         }
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new Error(`anthropic request failed: ${msg}`);
+        const raw_msg = e instanceof Error ? e.message : String(e);
+        throw new Error(`anthropic request failed: ${sanitizeError(raw_msg, capturedApiKey)}`);
       }
 
       const res = raw as {

--- a/tests/providers/anthropic.test.ts
+++ b/tests/providers/anthropic.test.ts
@@ -327,6 +327,95 @@ test("complete: sanitizes API errors — never echoes the API key", async () => 
   }
 });
 
+// --- sanitizeError defense-in-depth tests ---------------------------------
+
+test("sanitizes the API key from APIError.message before throwing (defense-in-depth, even though SDK does not currently include it)", async () => {
+  const CANARY = "sk-ant-canary-key-DO-NOT-LEAK";
+  const create = mock(async () => {
+    // Simulate an Anthropic.APIError whose .message happens to contain the key.
+    const e: Error & { status?: number } = Object.assign(
+      new Error(`rate limit exceeded key=${CANARY}`),
+      { status: 429 },
+    );
+    throw e;
+  });
+  const stub: AnthropicLike = { messages: { create } };
+  const provider = createAnthropicProvider({ apiKey: CANARY, client: stub });
+
+  let caught: Error | null = null;
+  try {
+    await provider.complete({
+      model: "claude-sonnet-4-6",
+      messages: [],
+      tools: [],
+      system: "",
+    });
+  } catch (e) {
+    caught = e as Error;
+  }
+  expect(caught).not.toBeNull();
+  expect(caught!.message).not.toContain(CANARY);
+  expect(caught!.message).toContain("<redacted>");
+});
+
+test("sanitizes the API key from non-APIError errors (the fallback path)", async () => {
+  const CANARY = "sk-ant-canary-fallback-DO-NOT-LEAK";
+  const create = mock(async () => {
+    // Throw a plain Error (no .status) so the fallback else-branch is taken.
+    throw new Error(`network error token=${CANARY}`);
+  });
+  const stub: AnthropicLike = { messages: { create } };
+  const provider = createAnthropicProvider({ apiKey: CANARY, client: stub });
+
+  let caught: Error | null = null;
+  try {
+    await provider.complete({
+      model: "claude-sonnet-4-6",
+      messages: [],
+      tools: [],
+      system: "",
+    });
+  } catch (e) {
+    caught = e as Error;
+  }
+  expect(caught).not.toBeNull();
+  expect(caught!.message).not.toContain(CANARY);
+  expect(caught!.message).toContain("<redacted>");
+});
+
+test("regression: existing canary test still passes — normal SDK error message is not mangled when key is absent", async () => {
+  const CANARY = "sk-ant-canary-regression-key";
+  const create = mock(async () => {
+    // Throw an API-shaped error whose message does NOT contain the key.
+    const e: Error & { status?: number } = Object.assign(
+      new Error("rate limit exceeded"),
+      { status: 429 },
+    );
+    throw e;
+  });
+  const stub: AnthropicLike = { messages: { create } };
+  const provider = createAnthropicProvider({ apiKey: CANARY, client: stub });
+
+  let caught: Error | null = null;
+  try {
+    await provider.complete({
+      model: "claude-sonnet-4-6",
+      messages: [],
+      tools: [],
+      system: "",
+    });
+  } catch (e) {
+    caught = e as Error;
+  }
+  expect(caught).not.toBeNull();
+  // The message must not contain the key (unchanged from before).
+  expect(caught!.message).not.toContain(CANARY);
+  // The message must NOT be mangled with spurious "<redacted>" tokens
+  // when the key was never present.
+  expect(caught!.message).not.toContain("<redacted>");
+  expect(caught!.message).toMatch(/anthropic /);
+});
+
 // --- boundary: thinking without signature, empty content array ------------
 
 test("fromAnthropicBlock: thinking block without signature", () => {


### PR DESCRIPTION
## Summary

Pentest finding **M11 (MEDIUM)** — `src/providers/anthropic.ts:144-159` catch block uses `apiErr.message` for `Anthropic.APIError` and falls through to `e.message` otherwise. Today neither path leaks the API key under known SDK behavior (existing canary regression test pins this). However, the fallback path (`!instanceof Anthropic.APIError` — bundler dual-instance, future SDK change putting key in `cause.url` / similar) bypasses any sanitizer.

This is a defense-in-depth gap — invisible until a future SDK version starts embedding the key, at which point the silence becomes a leak.

Fix: pipe both branches through a shared `sanitizeError(msg, apiKey)` helper that strips any substring equal to the API key (`split.join` idiom — same as `src/channels/telegram.ts` `callApi` redaction).

References: ADR-0005 (existing canary discipline), pentest report 2026-05-03 (M11).

## Test plan

- [x] `bun test tests/providers/anthropic.test.ts` — +3 new tests (APIError path sanitization, fallback path sanitization, regression: existing canary still passes)
- [x] `bun test` — 320 → 323 pass, full suite green
- [x] `bunx tsc --noEmit` — clean
- [x] Both code paths now mechanically scrub the api key before any error escapes the provider
