### PR TITLE
ci: add typecheck + test workflow with ci-pass aggregator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.3.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.5
+    - run: bun install --frozen-lockfile
+    - run: bun run typecheck
+    - name: Run tests
+      if: always()
+      run: bun test
+
+  ci-pass:
+    if: ${{ always() }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify build succeeded
+      if: ${{ needs.build.result != 'success' }}
+      run: exit 1


### PR DESCRIPTION
## Summary

- Bootstraps GitHub Actions for mote: a single `build` job runs `bun run typecheck` then `bun test`, and a `ci-pass` aggregator gates on the build result
- The `ci-pass` name is the stable contract for cross-repo coordination — once green on `main`, `paveg/gh-infra` can require it as a status check via a follow-up manifest PR without ever needing to know which internal jobs exist
- Triggers on `pull_request` and `push: branches: [main]` so the post-merge run on `main` registers `ci-pass` with GitHub as a check name

## Design notes

- **Bun pinned to 1.3.5**: the version where local `bun run typecheck` exits clean and `bun test` reports `360 pass, 1 skip, 0 fail`. Updates should be deliberate, not floating
- **`bun install --frozen-lockfile`**: lockfile is authoritative; CI fails on drift instead of silently re-resolving
- **`permissions: contents: read`** at workflow level: defense-in-depth alongside the repo-level `actions.workflow_permissions: read` declared in `paveg/gh-infra` mote manifest. Both can drift independently; both being explicit means one slipping doesn't lose the property
- **`if: always()` on the test step**: even if `typecheck` fails, tests still run so a single PR shows the full diagnostic surface
- **No SHA pinning on `actions/checkout@v4` / `oven-sh/setup-bun@v2`**: matches the `sha_pinning_required: false` policy in the manifest. Tightening to SHA pins is a separate hardening PR
- **No lint job**: `package.json` has no lint script. Adding one (Biome / oxlint / etc.) is a separate decision

## Sequencing context

This PR is **step 1 of a 3-step sequence** (chosen path A from the previous discussion):

1. ← **this PR**: add CI to mote
2. After merge, verify the `main` workflow run shows `ci-pass` as green
3. Open follow-up PR on `paveg/gh-infra` adding `required_status_checks: [{ context: ci-pass, app: github-actions }]` to the mote manifest's `default branch` ruleset

Order matters: doing 3 before 2 would deadlock the repo (every PR stuck waiting for a check that GitHub doesn't know about).

## Test plan

- [ ] CI workflow runs on this PR and passes (`build` green, `ci-pass` green)
- [ ] After merge, `CI` workflow runs once on `main` and `ci-pass` appears as a registered check name in repo Settings → Branches/Rules dropdown
- [ ] Follow-up gh-infra PR plan output shows `+ context: ci-pass` under the ruleset diff
