### PR TITLE
ci: bump actions/checkout v4 → v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.3.5


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from `@v4` to `@v6` in `.github/workflows/ci.yml`.

## Why

`actions/checkout@v6.0.2` (released 2026-01-09) is the current latest. v6 ships on Node 24 runners. v4 is still supported, but new workflows have no reason to start there.

`oven-sh/setup-bun@v2` is already on the latest major (`2.2.0` floats in via the `@v2` tag) — no change needed.

## Risk

Minimal. `actions/checkout` is a first-party action; the API surface used here (`uses: actions/checkout@v6` with no inputs) is unchanged across v4 → v6. The only meaningful difference is the runner's Node version.

## Test plan

- [ ] CI run on this PR shows `build` green and `ci-pass` green
- [ ] No deprecation warnings about Node 16/20 in the run logs
